### PR TITLE
Added special pricing tab to simple product edit page

### DIFF
--- a/src/Menu/AdminProductFormMenuListener.php
+++ b/src/Menu/AdminProductFormMenuListener.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brille24\SyliusSpecialPricePlugin\Menu;
+
+
+use Sylius\Bundle\AdminBundle\Event\ProductMenuBuilderEvent;
+
+final class AdminProductFormMenuListener
+{
+    /**
+     * @param ProductMenuBuilderEvent $event
+     */
+    public function addItems(ProductMenuBuilderEvent $event): void
+    {
+        $menu = $event->getMenu();
+
+        if ($event->getProduct()->isConfigurable()) {
+            return;
+        }
+
+        $specialPricingsTab = '@Brille24SyliusSpecialPricePlugin/Resources/views/Admin/ProductVariant/Tab/_specialPricings.html.twig';
+        $menu
+            ->addChild('channelSpecialPricings')
+            ->setAttribute('template', $specialPricingsTab)
+            ->setLabel('brille24.form.channel_special_price.special_prices')
+            ->setLabelAttribute('icon', 'dollar');
+    }
+}

--- a/src/Resources/config/di/event_listener.xml
+++ b/src/Resources/config/di/event_listener.xml
@@ -1,0 +1,9 @@
+<container xmlns="http://symfony.com/schema/dic/services">
+    <services>
+        <service class="Brille24\SyliusSpecialPricePlugin\Menu\AdminProductFormMenuListener"
+                 id="brille24.sylius_special_price_plugin.menu.admin_product_form_menu_listener"
+        >
+            <tag name="kernel.event_listener" event="sylius.menu.admin.product.form" method="addItems" />
+        </service>
+    </services>
+</container>

--- a/src/Resources/views/Admin/ProductVariant/Tab/_specialPricings.html.twig
+++ b/src/Resources/views/Admin/ProductVariant/Tab/_specialPricings.html.twig
@@ -1,0 +1,9 @@
+{% block content %}
+    <div class="ui tab" data-tab="channelSpecialPricings">
+        {% set variantForm = form.variant %}
+
+        {% include 'Brille24SyliusSpecialPricePlugin::_specialPrice.html.twig' with {
+            'form': variantForm.channelSpecialPricings
+        } %}
+    </div>
+{% endblock %}


### PR DESCRIPTION
This fixes a bug where saving a simple product removes the special pricings from the variant. 