### PR TITLE
Fix unable to find templates

### DIFF
--- a/src/Menu/AdminProductFormMenuListener.php
+++ b/src/Menu/AdminProductFormMenuListener.php
@@ -19,7 +19,7 @@ final class AdminProductFormMenuListener
             return;
         }
 
-        $specialPricingsTab = '@Brille24SyliusSpecialPricePlugin/Resources/views/Admin/ProductVariant/Tab/_specialPricings.html.twig';
+        $specialPricingsTab = '@Brille24SyliusSpecialPricePlugin/Admin/ProductVariant/Tab/_specialPricings.html.twig';
         $menu
             ->addChild('channelSpecialPricings')
             ->setAttribute('template', $specialPricingsTab)

--- a/src/Resources/views/Admin/ProductVariant/Tab/_specialPricings.html.twig
+++ b/src/Resources/views/Admin/ProductVariant/Tab/_specialPricings.html.twig
@@ -2,7 +2,7 @@
     <div class="ui tab" data-tab="channelSpecialPricings">
         {% set variantForm = form.variant %}
 
-        {% include 'Brille24SyliusSpecialPricePlugin::_specialPrice.html.twig' with {
+        {% include '@Brille24SyliusSpecialPricePlugin/_specialPrice.html.twig' with {
             'form': variantForm.channelSpecialPricings
         } %}
     </div>


### PR DESCRIPTION
I received some errors for template paths while using version 1.10 of this plugin in Sylius 1.9.6. Figured out this was due to the reference to paths of two templates.